### PR TITLE
High level architecture description of Base Layer

### DIFF
--- a/proposals/181102-high-level-design.md
+++ b/proposals/181102-high-level-design.md
@@ -82,6 +82,8 @@ the network.
 _TODO_: Difference between pruned nodes and archival nodes, particularly WRT to syncing
 
 
+# Disclaimer
 
+This document is subject to the [disclaimer](../DISCLAIMER.md).
     
     

--- a/proposals/181102-high-level-design.md
+++ b/proposals/181102-high-level-design.md
@@ -1,0 +1,87 @@
+# High level design
+
+## Base layer responsibilities
+
+The Tari Base Layer has the following jobs:
+
+* Record every [Tari coin]() transfer in history in an immutable public ledger, or [blockchain](./181105-terms
+.md#blockchain).
+* Allow users to prove ownership of Tari coins.
+* Reward miners for securing the network by issuing new coins in [Coinbase Transaction](./181105-terms
+.md#coinbase-transaction)s
+* Validate all Tari coin [transactions](181105-terms.md#transactions).
+* Provide a set of higher-order transaction formats to facilitate:
+  * Multi-signature transactions
+  * Atomic swaps
+  * Recording Digital asset state checkpoint summaries
+  * Registering of 2nd-layer nodes and their bonded collateral
+  * Act as arbitrator in second-layer disputes
+  * Zero-knowledge contingent payments
+ 
+The Tari Base layer will be based on the MimbleWimble protocol and implemented as a proof-of-work-based blockchain. 
+The proof of work will be performed via merge mining with Monero. Arguments for this design are presented [in the 
+overview](./181029-overview.md).
+
+## Monero merge mining
+
+Proof of work (PoW) plays three key functions in blockchains:
+* To act as a random Oracle
+* Make it very expensive to rewrite the transaction history
+
+[Merge mining](https://tari-labs.github.io/tari-university/merged-mining/merged-mining-scene/MergedMiningIntroduction.html)
+ allows a blockchain to bootstrap hash rate from an established blockchain.
+ 
+### Standalone miners
+ 
+Monero-only miners _do not need to know about_ Tari. However, a Tari-enabled Monero merge mining implementation 
+requires the following:
+
+* A full Monero mining implementation
+  * Monero block selection module
+  * Monero mempool module
+  * Monero block propagation module
+* Modifications to the Monero Coinbase transaction.
+* The Tari mining implementation
+  * The Tari block selection code
+  * Tari block propagation
+  * Tari mempool module
+  
+### Pool mining
+
+The majority of Monero miners opt to use a mining pool rather than run a standalone mining operation. 
+
+Providing support for mining pool operators is something we should strongly consider. There are 2 main open-source 
+mining pool source codes, including
+
+* https://github.com/zone117x/node-cryptonote-pool
+* https://github.com/Snipa22/nodejs-pool
+
+Our contributions would comprise 
+* modifying Monero block templates, 
+* interfacing with the Tari full node.
+* communicate with Tari standalone mining module to build Taro block templates
+* modify stratum server communications for handling Tari reward shares
+* Write the stratum API implementation for clients
+* _TODO: What else?_
+
+## Full node software
+
+A Tari full node performs the following critical jobs in maintaining the integrity of the Tari base layer.
+
+* It's responsible for the propagation of Tari transactions to the rest of the network
+* It validates every transaction received and silently drops invalid transactions, while propagating valid ones.
+* It's responsible for propagating new valid blocks to the rest of the base layer network
+* It validates every new block received, silently dropping invalid ones and propagating valid blocks to the rest of 
+the network.
+* It provides a historical blockchain data to help peers sync up on blockchain history
+* Exposes an API to clients (esp SPV clients and wallets) for 
+  * Block queries
+  * Kernel data queries
+  * New transaction requests
+
+_TODO_: Difference between pruned nodes and archival nodes, particularly WRT to syncing
+
+
+
+    
+    

--- a/proposals/181102-high-level-design.md
+++ b/proposals/181102-high-level-design.md
@@ -4,7 +4,7 @@
 
 The Tari Base Layer has the following jobs:
 
-* Record every [Tari coin]() transfer in history in an immutable public ledger, or [blockchain](./181105-terms
+* Record every [Tari coin](181105-terms.md#tari-coin) transfer in history in an immutable public ledger, or [blockchain](181105-terms
 .md#blockchain).
 * Allow users to prove ownership of Tari coins.
 * Reward miners for securing the network by issuing new coins in [Coinbase Transaction](./181105-terms

--- a/proposals/181105-terms.md
+++ b/proposals/181105-terms.md
@@ -3,53 +3,100 @@ Below are a list of terms and their definitions that are used throughout the Tar
 this glossary to disambiguate ideas, and work towards a 
 [ubiquitous language](https://blog.carbonfive.com/2016/10/04/ubiquitous-language-the-joy-of-naming/) for this project.  
 
-## Block reward
-[Block Reward]: #block_reward 'The amount of Tari created in every block'
+## Base layer
+[Base Layer]: #Base-layer 'The Tari layer handling payments and secured by proof of work'
 
-The amount of Tari created in every block
+The Tari Base layer is a merge-mined [blockchain] secured by proof-of-work. The base layer is primarily responsible for 
+the emission of new Tari, for securing and managing [tari coin] transfers.
+
+## Base Node
+[base node]: #base-node 'A full Tari node running on the base layer, validating and propagating tari coin 
+transactions and blocks'
+
+A full Tari node running on the base layer. It's primary role is validating and propagating tari coin transactions 
+and blocks to the rest of the network.
+
+## Block
+[block]: #Block 'A collection transactions and associated metadata recorded as a single entity in the Tari blockchain'
+
+A collection transactions and associated metadata recorded as a single entity in the Tari blockchain. The ordering of
+ Tari transactions is set purely by the block height of the block they are recorded in. 
+
+## Block reward
+[block reward]: #Block-reward 'The amount of Tari created in every block'
+
+The amount of Tari created by the coinbase transaction in every block. The block reward is set by the 
+[emission schedule].
 
 ## Blockchain
-[blockchain]: #blockchain 'A sequence of Tari blocks'
+[blockchain]: #Blockchain 'The linked sequence of Tari blocks on the Tari base layer'
 
-A sequence of [Tari block]s. Each block contains a hash of the previous valid block. Thus the blocks form a chain 
+A sequence of tari [block]s. Each block contains a hash of the previous valid block. Thus the blocks form a chain 
 with the property that changing anything in a block other than the head block requires rewriting the entire 
 blockchain from that point on.
 
 ## Coinbase transaction 
-[Coinbase Transaction]: coinbase_transaction 
+[coinbase transaction]: #Coinbase-transaction 
 
-The first transaction in every Tari block yields a [Block Reward] according to the Tari [Emmission Schedule] and is 
-awarded to the miner that performed the [Proof of Work] for the block.
+The first transaction in every Tari block yields a [Block Reward] according to the Tari [emission Schedule] and is 
+awarded to the miner that performed the Proof of Work for the block.
 
-## Emmission Schedule
-[Emmission Schedule]: #emmision_schedule 
+## Digital asset
+[digital asset]: #digital-asset 'Sets of Native digital tokens, both fungible and non-fungible that are created by 
+asset issuers on the Tari 2nd layer'
 
-An explicit formula as a function of the block height, _h_, that determined what the block reward for the 
-_h_<sup>th</sup> block is.
+Digital assets (DAs) are the sets or collections of native digital tokens (both fungible and non-fungible) that are 
+created
+ by asset issuers on the Tari 2nd layer. For example, a promoter might create a DA for a music concert event. The 
+ event is the digital asset, and the tickets for the event are digital asset [tokens].
+ 
+## Digital asset tokens
+[tokens]: #Digital-asset-tokens 'or just, "tokens". The tokens associated with a given digital asset. Tokens are created
+ by asset issuers'
 
-## Transactions
-[transaction]: #transactions 
+Digital asset tokens (or often, just "tokens") are the finite set of digital entities associated with a given digital 
+asset. Depending on the DA created, tokens can represent tickets, in-game items, collectibles or loyalty points. They
+ are bound to the [digital asset] that created them.
 
-Transactions are activities recorded on the Tari [blockchain]. The types of transactions accepted on the Tari 
-blockchain are:
-* [Coinbase transaction]s
-* _Spend transactions_. Here one or more UTXOs are destroyed (the input UTXOs), yielding a new set of UTXOs whose value
- sum to the sum of the input UTXO value minus the transaction fee.
-* _Checkpoint transactions_. A special spend transaction that contains a single input UTXO, an optional 
-change UTXO, timestamped and signed merkle root, and a transaction fee. _Does this *need* to be a separate 
-transactino type, or should we allow an arbitrary number of merkle proofs in standard spend transactions?_
+## Emission schedule
+[emission schedule]: #emission-schedule 
+
+An explicit formula as a function of the block height, _h_, that determines the block reward for the 
+_h_<sup>th</sup> block.
+
+## MimbleWimble
+[mimblewimble]: #mimblewimble 'a privacy-centric cryptocurrency protocol'
+MimbleWimble is a privacy-centric cryptocurrency protocol. It was [dropped](https://download.wpsoftware.net/bitcoin/wizardry/mimblewimble.txt) in the Bitcoin 
+Developers chatroom by an anonymous author and has since been refined by several authors, including Andrew Poelstra.
+
+## ProtoTransaction
+[prototransaction]: #prototransaction 'A new transaction from a client, such as a wallet'
+
+When a client application, such as a wallet submits a new transaction request to the network, it is not a 
+fully-fledged transaction. For instance 
+
+## Transaction
+[transaction]: #transaction 'Base layer tari coin transfers.'
+
+Transactions are activities recorded on the Tari [blockchain] running on the [base layer]. Transactions always 
+involve a transfer of [tari coins].
 
 ## Tari Coin
-[tari coin]: #tari_coin
+[tari coin]: #tari-coin 'The base layer token'
 
-The base layer token.
+The base layer token. Tari coins are released according to the [emission schedule] on the Tari [base layer] 
+[blockchain] in [coinbase transaction]s.
  
 ## Unspent transaction outputs
-[utxo]: #unspent_transaction_outputs
+[utxo]: #unspent-transaction-outputs
 
 An unspent transaction output (UTXO) is a discrete number of Tari that are available to be spent. The sum of all 
 UTXOs represents all the Tari currently in circulation. In addition, the sum of all UTXO values equals the sum of the
  [block reward]s for all blocks up to the current block height.
  
 UTXO values are hidden by their commitments. Only the owner of the UTXO and (presumably) the creator of the UTXO 
-(either a [Coinbase transaction] or previous spender) know the value of the UTXO. 
+(either a [Coinbase transaction] or previous spender) know the value of the UTXO.
+
+# Disclaimer
+
+This document is subject to the [disclaimer](../DISCLAIMER.md). 

--- a/proposals/181105-terms.md
+++ b/proposals/181105-terms.md
@@ -1,0 +1,55 @@
+# Tari Network Terminology
+Below are a list of terms and their definitions that are used throughout the Tari code and documentation. Let's use 
+this glossary to disambiguate ideas, and work towards a 
+[ubiquitous language](https://blog.carbonfive.com/2016/10/04/ubiquitous-language-the-joy-of-naming/) for this project.  
+
+## Block reward
+[Block Reward]: #block_reward 'The amount of Tari created in every block'
+
+The amount of Tari created in every block
+
+## Blockchain
+[blockchain]: #blockchain 'A sequence of Tari blocks'
+
+A sequence of [Tari block]s. Each block contains a hash of the previous valid block. Thus the blocks form a chain 
+with the property that changing anything in a block other than the head block requires rewriting the entire 
+blockchain from that point on.
+
+## Coinbase transaction 
+[Coinbase Transaction]: coinbase_transaction 
+
+The first transaction in every Tari block yields a [Block Reward] according to the Tari [Emmission Schedule] and is 
+awarded to the miner that performed the [Proof of Work] for the block.
+
+## Emmission Schedule
+[Emmission Schedule]: #emmision_schedule 
+
+An explicit formula as a function of the block height, _h_, that determined what the block reward for the 
+_h_<sup>th</sup> block is.
+
+## Transactions
+[transaction]: #transactions 
+
+Transactions are activities recorded on the Tari [blockchain]. The types of transactions accepted on the Tari 
+blockchain are:
+* [Coinbase transaction]s
+* _Spend transactions_. Here one or more UTXOs are destroyed (the input UTXOs), yielding a new set of UTXOs whose value
+ sum to the sum of the input UTXO value minus the transaction fee.
+* _Checkpoint transactions_. A special spend transaction that contains a single input UTXO, an optional 
+change UTXO, timestamped and signed merkle root, and a transaction fee. _Does this *need* to be a separate 
+transactino type, or should we allow an arbitrary number of merkle proofs in standard spend transactions?_
+
+## Tari Coin
+[tari coin]: #tari_coin
+
+The base layer token.
+ 
+## Unspent transaction outputs
+[utxo]: #unspent_transaction_outputs
+
+An unspent transaction output (UTXO) is a discrete number of Tari that are available to be spent. The sum of all 
+UTXOs represents all the Tari currently in circulation. In addition, the sum of all UTXO values equals the sum of the
+ [block reward]s for all blocks up to the current block height.
+ 
+UTXO values are hidden by their commitments. Only the owner of the UTXO and (presumably) the creator of the UTXO 
+(either a [Coinbase transaction] or previous spender) know the value of the UTXO. 

--- a/proposals/181107-base-layer-architecture.md
+++ b/proposals/181107-base-layer-architecture.md
@@ -1,0 +1,85 @@
+# Base Layer Architecture
+
+## Summary
+
+The Tari base layer is based on the [MimbleWimble] protocol and is merge-mined with Monero.
+
+Major base layer modules:
+
+* Transaction validation and propagation.
+* Blockchain management, including block propagation, block validation, seeding and syncing.
+* Merge mining
+* APIs for clients (wallets, block explorers and peers)
+
+Support modules:
+* Cryptography
+* A general peer-to-peer messaging service. The interface is abstracted to the point that it 
+is reasonably easy to switch out different backends, whether it's IPv4, Tor, I2P etc. The same communication protocol
+ should be employed for the second layer.
+* Data storage.
+
+## Infrastructure layer
+
+The infrastructure layer doesn't know anything about blockchains, transactions, or digital assets. This layer offers 
+a set of modules upon which we build the Tari infrastructure.
+
+### Peer-to-peer messaging
+
+[ØMQ]((http://zguide.zeromq.org)) is a mature distributed communications framework. It's 
+very lightweight, is very fast and has excellent documentation. ØMQ forms the basis for peer-to-peer and inter-process
+ messaging in Tari.
+ 
+Tari follows a loosely coupled, pub-sub message-based approach to message passing. 
+
+[Message producers] create messages and put them onto the message bus. Any service or module that is interested in 
+those messages can subscribe to receive them. With ØMQ, it's relatively straightforward to
+ allow publishers and subscribers to be on the same machine in different threads, or across the world.   
+
+Messages in Tari are serialized into the binary [MessagePack](https://msgpack.org/index.html) format
+### Data storage
+
+[LMBD](http://www.lmdb.tech/doc/) is a very lightweight key-value store. It is incredibly fast and memory-efficient 
+and is used as the persistent storage layer in Monero and Grin, among others.
+
+### Cryptographic services
+
+Tari uses Curve25519 for EC cryptography. The [dalek libraries](https://github.com/dalek-cryptography/curve25519-dalek) 
+are a native Rust implementation.  
+
+## Domain layer modules
+
+### Transaction Listener Service
+
+Transactions are received from the [TransactionListener] service, which makes use of  
+
+* [Introduction to MimbleWimble](intro.md)
+* Cryptographic Primitives
+  * Pedersen Commitments
+  * Aggregate (Schnorr) Signatures
+    * Bulletproofs
+* Block and Transaction Format
+  * Transaction
+    * Input, output
+    * Kernel
+  * Block
+    * Header
+    * Body
+    * Compact Block
+* Chain State and Merkle Mountain Range
+  * Motivation
+  * [Merkle Mountain Range](mmr.md)
+  * [State and Storage](state.md)
+  * [Fast Sync](fast-sync.md)
+  * Merkle Proofs
+* Proof of Work
+  * Cuckoo Cycle
+  * Difficulty Algorithm
+* Wire protocol
+  * Seeding and Sync
+  * Propagation
+  * Low-level Messages
+* Dandelion & Aggregation
+* Building Transactions
+* Important Parameters
+  * Fees and Transaction Weight
+  * Reward and Block Weight

--- a/proposals/181107-base-layer-architecture.md
+++ b/proposals/181107-base-layer-architecture.md
@@ -11,19 +11,17 @@ Major base layer modules:
 * Merge mining
 * APIs for clients (wallets, block explorers and peers)
 
-Support modules:
-* Cryptography
-* A general peer-to-peer messaging service. The interface is abstracted to the point that it 
-is reasonably easy to switch out different backends, whether it's IPv4, Tor, I2P etc. The same communication protocol
- should be employed for the second layer.
-* Data storage.
+Support modules (infrastructure):
+* A general peer-to-peer messaging service ([MessageBus](#messagebus)).
+* [Data storage](#data-storage).
+* [Cryptography](#cryptographic-module)
 
 ## Infrastructure layer
 
 The infrastructure layer doesn't know anything about blockchains, transactions, or digital assets. This layer offers 
 a set of modules upon which we build the Tari infrastructure.
 
-### Peer-to-peer messaging
+### MessageBus
 
 [ØMQ]((http://zguide.zeromq.org)) is a mature distributed communications framework. It's 
 very lightweight, is very fast and has excellent documentation. ØMQ forms the basis for peer-to-peer and inter-process
@@ -31,55 +29,279 @@ very lightweight, is very fast and has excellent documentation. ØMQ forms the b
  
 Tari follows a loosely coupled, pub-sub message-based approach to message passing. 
 
-[Message producers] create messages and put them onto the message bus. Any service or module that is interested in 
-those messages can subscribe to receive them. With ØMQ, it's relatively straightforward to
- allow publishers and subscribers to be on the same machine in different threads, or across the world.   
+Messages in Tari are serialized into the binary [MessagePack](https://msgpack.org/index.html) format before being put
+ onto the wire. 
+ 
+Messages come from various sources - peers, other processes on the same machine, or clients accessing the APIs. The 
+data in the messages is invisible to MessageBus. All it sees is a string of bytes (that can be deserialized by serde 
+and the MessagePack library).
 
-Messages in Tari are serialized into the binary [MessagePack](https://msgpack.org/index.html) format
+The MessageBus architecture follows a fan-in, fan-out pattern. An arbitrary number of MessagePublishers connect to a 
+single MessageBroker object that passes messages on to an arbitrary number of MessageSubscribers. MessagePublishers 
+are implementation-specific classes that, e.g. collect messages from peer nodes over I2P, or HTTP, or from a mining 
+pool over Stratum. The MessagePublishers MAY format messages if desired, but MUST deliver messages to the 
+MessageBroker in MessagePack format.
+
+Messages SHOULD have the MessageType field as the first field in its serialization.
+
+The MessageBroker MUST NOT modify the message.
+
+MessageSubscribers connects to the MessageBroker and MUST specify a filter for messages it is interested in. This is 
+achieved by calling the `setFilter` method every MessageBroker MUST implement, which sets the message filter. The 
+filter is based on the MessageType field which SHOULD be present as the first field in every message.
+
+MessageSubscribers MUST subscribe to either one message type, or all messages.
+
+The MessageBroker MUST send every message to every MessageSubscriber that has a filter on for that type of message. 
+
+The basic structure looks as follows:
+
+```text
+         Stratum                  Peer Nodes                REST API
+            +                         +                        +
+            |                         |                        |
+            |                         |                        |
+  +---------+---------+     +---------+---------+     +--------+----------+
+  |  MessagePublisher |     |  MessagePublisher |     |  MessagePublisher |
+  +-------------------+     +-------------------+     +-------------------+
+  |       PUSH        |     |        PUSH       |     |       PUSH        |
+  +---------+---------+     +---------+---------+     +---------+---------+
+            |                         |                         |
+            |                         |                         |
+            |                         |                         |
+            |                         |                         |
+            |                         |                         |
+            |                         |                         |
+            |               +---------v--------+                |
+            +--------------->       PULL       <----------------+
+                            +------------------+
+                            |   MessageBroker  |
+                            +------------------+
+                            |       PUB        |
+           +----------------+--------+---------+---------------+
+           |                         |                         |
+           |                         |                         |
+           |                         |                         |
+           |                         |                         |
++----------v--------+      +---------v---------+     +---------v---------+
+|        SUB        |      |        SUB        |     |        SUB        |
++-------------------+      +-------------------+     +-------------------+
+| MessageSubscriber |      | MessageSubscriber |     | MessageSubscriber |
++-------------------+      +-------------------+     +-------------------+
+```
+
+The MessageBus is constructed in a very general way, so that the same infrastructure can be used for both base and 
+second layer messaging.
+
+The MessageBus is locked into using ØMQ, but Messages implement the `Serializable` trait from serde, so that the binary
+ protocol can be swapped out if desired.
+
+The MessageBus can be used for both internal (inter-thread or in-process) messaging using `ipc` or `inproc` 
+transports, as well as external messaging using `tcp`. 
+
+The MessageBus can also be augmented with 0MQ pipelines (using PUSH, PULL, ROUTER and DEALER sockets), which are 
+analogous to node.js stream pipes.
+
 ### Data storage
 
-[LMBD](http://www.lmdb.tech/doc/) is a very lightweight key-value store. It is incredibly fast and memory-efficient 
-and is used as the persistent storage layer in Monero and Grin, among others.
+The DataStorage module presents an abstracted API for persisting data (presumably to disk). This allows Tari to swap 
+out the persistence implementation without affecting modules that depend on it.
+ 
+[LMDB](http://www.lmdb.tech/doc/) is a very lightweight key-value store. It is incredibly fast and memory-efficient 
+and is used as the persistent storage layer in Monero and Grin, among others. LMDB's success in these projects make 
+it a natural choice as the default persistence solution for Tari.
 
-### Cryptographic services
+_TODO_:
+* Define the DataStorage API
+
+### Cryptographic module
+
+The Tari crypto module provides an abstraction layer for:
+
+* Deterministic key generation
+* Message signing
+* Signature verification
+* Signature aggregation (MuSig)
+* Multisig operations
+* Commitments (Pederson)
+* Threshold cryptography
+* Range Proofs
+* Bulletproofs
+* Symmetric encryption
+
+The crypto API is presented as a collection of traits so that the backend (Curve25519) can be swapped out without 
+impacting any modules making use of the module. 
 
 Tari uses Curve25519 for EC cryptography. The [dalek libraries](https://github.com/dalek-cryptography/curve25519-dalek) 
-are a native Rust implementation.  
+are a native Rust implementation. 
+
 
 ## Domain layer modules
 
-### Transaction Listener Service
+The Domain layer houses the Tari "business logic". All protocol-related concepts and procedures are defined and 
+implemented here. The domain layer makes use of modules on the infrastructure layer to achieve its goals, but the 
+infrastructure layer knows nothing about anything implemented here.
 
-Transactions are received from the [TransactionListener] service, which makes use of  
+This entails that any and all terms defined in the [Glossary] will have a software implementation here, and only here.
 
-* [Introduction to MimbleWimble](intro.md)
-* Cryptographic Primitives
-  * Pedersen Commitments
-  * Aggregate (Schnorr) Signatures
-    * Bulletproofs
-* Block and Transaction Format
-  * Transaction
-    * Input, output
-    * Kernel
-  * Block
-    * Header
-    * Body
-    * Compact Block
-* Chain State and Merkle Mountain Range
-  * Motivation
-  * [Merkle Mountain Range](mmr.md)
-  * [State and Storage](state.md)
-  * [Fast Sync](fast-sync.md)
-  * Merkle Proofs
-* Proof of Work
-  * Cuckoo Cycle
-  * Difficulty Algorithm
-* Wire protocol
-  * Seeding and Sync
-  * Propagation
-  * Low-level Messages
-* Dandelion & Aggregation
-* Building Transactions
-* Important Parameters
-  * Fees and Transaction Weight
-  * Reward and Block Weight
+### Base layer nodes
+
+[Base node]s perform the following:
+
+#### Listen for new [Transaction] messages by subscribing to the `MessageBroker` as a `TransactionMessageSubscriber`
+
+* When a new message is received, check whether the `Transaction` is valid by 
+  * verifying all signatures in the `Transaction`
+  * checking the `Transaction` accounting (specifically that the excess is  valid public key)
+  * verifying all the range proofs in the `Transaction`
+* If a new `Transaction` is valid,
+  * Mark it as verified (is this how we want to handle this???)
+  * Push the Verified Transaction onto the internal `MessageBus`
+
+#### Listen for new [Block] messages by subscribing to the `MessageBroker` as a `BlockMessageSubscriber`
+  
+* When a new block is received, check whether the block is valid by
+  * Verifying the `BlockHeader`
+  * Verifying the `ProofOfWork`
+  * Verifying every `Transaction` in the block
+  * Verifying that the block is being added to the chain tip 
+* If the block is not being added to the chain tip, but is otherwise valid, check for chain reorgs
+* If the block is valid, 
+  * add it to the chain tip
+  * transmit the block to its peers
+
+#### Listen for new peer connection requests
+
+When a new connection request is received, the node will check whether the peer has been blacklisted.
+If not, it will allow the connection and add the peer to the `Peers` list.
+
+#### Tell peers about new transactions
+
+#### Tell peers about new blocks
+
+#### Seeding and synchronizing
+
+When base nodes start up, they need to synchronize the blockchain with their peers. Nodes need to have the 
+following functionality to achieve this:
+* Connect to peer
+* Request peer list from peer
+* Request most recent chain state (total accumulated work, block height etc)
+* Request blocks from peer
+* Request `Transaction`s from peer
+* Send requested blocks to peer
+
+### The Mempool 
+
+The mempool is a database of all unconfirmed, VALID, transactions. The mempool is used in the following situations:
+* For mining nodes to select transactions to build new blocks
+* To use as a cross-checking reference for checking whether a new transaction is valid
+
+The mempool adds transactions to the pool by listening for `NewVerifiedTransaction` messages on the internal 
+`MessageBus`.
+
+The mempool also listens for `NewVerifiedBlock` messages.
+
+The mempool responds to requests for transaction lists according to a `BlockSelectionStrategy`, usually, something 
+that maximises fees for a certain block size, but mining nodes are free to select the strategy they desire.
+
+The mempool must respond to requests for whether a given UTXO is being used as an input in the mempool.
+
+The mempool removes transactions from the mempool when:
+* A `NewVerifiedBlock` messages arrives. All transactions listen in the block are removed from the mempool.
+* Memory constraints are reached, specified in a `MempoolPolicy`. The oldest and/or transactions with lowest fees will
+ be dropped according to the `MemPoolPolicy` in action.
+ 
+ 
+
+### Peer Broadcasting
+
+A `PeerBroadcaster` listens for specific messages on the internal `MessageBus` and then relays them to peers using a 
+`PeerBroadcastStrategy` (e.g. gossip or flood). Separate `PeerBroadcaster` instances will propagate transactions 
+and blocks. 
+
+_TODO_: Should syncing and seeding happen on dedicated ports, since they're not really as event driven? Or utilize the 
+same infrastructure? 
+ 
+ 
+### Transactions
+
+Transactions are what allows value transfer to occur in the Tari network. A full `Transaction` consists of
+
+* A `TransactionType` (Coinbase, Regular, Checkpoint, Collateral)
+* An array of zero or more `TransactionInput`s
+* An array of zero or more `TransactionOutput`s. Transaction outputs comprise
+  * A `Commitment` which blinds the value of the output (MW protocol suggests Pedersen commitments -- is it 
+  worthwhile abstracting this to allow other commitment types?)
+  * A `RangeProof` proving that the commitment value > 0
+  * A bitmask of `OutputFeatureFlags` 
+* A `TransactionKernel`, which contains: 
+  * Signatures for every output `BlindingFactor`
+  * A bitmask of `TransactionFeatures` for the `Transaction`
+  * The transaction fee in nanoTari
+  * The maturation schedule (determining when outputs can be spent)
+  * The `TransactionExcess`, which must be a valid public key for the accounting to hold
+  * A signature using the excess private key, proving knowledge that the excess value is known 
+  
+_TODO_: Grin includes these fields too. Figure out why they are necessary
+  * The max lock_height of all *inputs* to this transaction
+
+_Random Thought_: Is it better to have a single `Transaction` struct with a `is_valid` field (true, false. None), or  
+different types: `ValidatedTransaction`, `UnvalidatedTransaction` & `InvalidTransaction`? The latter form can leverage 
+Rust's static typing to prevent, _at compile time_ any bugs that would let an invalid transaction into a block, for example. It's 
+pretty cool, but I wonder if it's worth the effort / results in too much repetition of code?
+
+### Blocks
+
+In a decentralised proof-of-work ledgers, transactions cannot be reliably and unambiguously ordered by timestamp. 
+Instead, Nakamoto consensus defines transaction ordering by block sequence. Miners collect transactions into blocks 
+and publish them to the network to be included into the blockchain. Tari's base layer is based on the MimbleWimble
+ protocol; thus Tari blocks contain the following information:
+ 
+* A `BlockHeader` which contains various metadata about the `Transaction`s in the block, as well as a link to the 
+previous block in the chain.
+* The `BlockBody`, which contains all the `Transactions` in the block.
+
+The `BlockHeader` contains the following:
+* The block version number
+* The block height
+* The `BlockHash` of the previous block
+* A `BlockTimestamp` for this block
+* A `MerkleRoot` for the transaction commitments in the `BlockBody`
+* A `MerkleRoot` for the range proofs in the `BlockBody`
+* A `MerkleRoot` of all transaction kernels in the `BlockBody`
+* The `ProofOfWork` for the block, including
+    * The `MoneroBlockHeader` for the block - because we're merge mining
+
+_TODO_: Grin includes these fields too. Figure out why they are necessary:	
+  * Total accumulated sum of kernel offsets since genesis block.
+  *	Total accumulated sum of kernel commitments since genesis block. Should always equal the UTXO commitment sum 
+  minus supply.
+  * Total size of the output MMR after applying this block
+  * Total size of the kernel MMR after applying this block
+
+_Note_: The Grin implementation of MW splits transaction excesses into two values to prevent reconstructing of 
+individual transactions of blocks by analyzing the inputs and outputs. We should implement this feature to improve 
+privacy. 
+
+### TransactionMessageSubscriber
+
+The `TransactionMessageSubscriber` is a simple service that connects to the `MessageBroker` and filters all Transaction 
+messages originating from the network. It deserialises the message into a `Transaction` object before handing it over
+ to the connected client (typically a `BaseNode` instance). 
+ 
+### BlockMessageSubscriber
+
+Similarly, the `BlockMessageSubscriber` is a simple service that connects to the `MessageBroker` and filters 
+all Block messages originating from the network. It deserialises the message into a `Block` object before handing it 
+over to the connected client.
+
+  
+# Disclaimer
+
+This document is subject to the [disclaimer](../DISCLAIMER.md).
+
+[Glossary]: ./181105-terms.md "Glossary"
+[MimbleWimble]: ./181105-terms.md#mimblewimble
+[Base node]: ./181105-terms.md#base-node
+[transaction]: ./181105-terms.md#transaction
+[block]: ./181105-terms.md#block


### PR DESCRIPTION
This is a first stab at a high-level architecture description of the Tari base layer, based on MimbleWimble.
The ideas presented here come from the IRC chats on #tari-dev (freenode)

It includes:
* a fairly high-level overview of the major working pieces on the base layer
* a medium-level description of the base layer full node implementation; divided into an infrastructure layer (blockchain agnostic) and the domain layer (blockchain aware).
* The beginning of a glossary is also provided to help move towards the use of a ubiquitous language. 